### PR TITLE
Seperate scopes with space not comma, and use plural version of param name

### DIFF
--- a/app.py
+++ b/app.py
@@ -54,7 +54,7 @@ def signup():
     params = {
         'response_type': 'code',
         'redirect_uri': get_redirect_uri(request),
-        'scopes': ','.join(config.get('scopes')),
+        'scope': ' '.join(config.get('scopes')),
     }
     url = generate_oauth_service().get_authorize_url(**params)
     return redirect(url)


### PR DESCRIPTION
Per the Uber API, `scope` should be space separated, not comma separated. Use `scope` not `scopes` as well.

From https://developer.uber.com/v1/auth/

```
Space delimited list of grant scopes you would like to have permission to access on behalf of the user.
```
