### PR TITLE
Set debug=False by default

### DIFF
--- a/app.py
+++ b/app.py
@@ -229,5 +229,5 @@ def get_redirect_uri(request):
     return 'https://{hostname}/submit'.format(hostname=parsed_url.hostname)
 
 if __name__ == '__main__':
-    app.debug = os.environ.get('FLASK_DEBUG', True)
+    app.debug = os.environ.get('FLASK_DEBUG', False)
     app.run(port=7000)


### PR DESCRIPTION
This changes the app to run with DEBUG=False unless the environment variable for FLASK_DEBUG has been explicitly set. [Flask's docs](http://flask.pocoo.org/docs/0.10/quickstart/#debug-mode) include a note about how this should never be run on production with debug=True because it enables remote code execution. [Patreon](http://labs.detectify.com/post/130332638391/how-patreon-got-hacked-publicly-exposed-werkzeug) was supposedly just hacked because one of their test servers had debug=True enabled so I think it makes sense to keep it disabled by default in the interest of security.
